### PR TITLE
Update to remove download_as_string()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Change download_as_string() to download_as_bytes() due to deprecation.
 
 1.3.1
 -----

--- a/gsecrets/client.py
+++ b/gsecrets/client.py
@@ -63,7 +63,7 @@ class Client(object):
         # TODO: error handling if this file is missing or badly configured
         path = "keyring.json"
         blob = self.bucket.blob(path)
-        keyring_configuration = blob.download_as_string()
+        keyring_configuration = blob.download_as_bytes()
         keyring_configuration = json.loads(keyring_configuration)
         self.location = keyring_configuration["location"]
         self.keyring = keyring_configuration["keyring"]
@@ -184,7 +184,7 @@ class Client(object):
         blob = self.bucket.blob(path)
 
         try:
-            ciphertext = blob.download_as_string()
+            ciphertext = blob.download_as_bytes()
         except NotFound:
             raise SecretNotFound()
 


### PR DESCRIPTION
download_as_string() is deprecated in later google-cloud-storage, but the deprecation warning seems to be failing leading to an error when it is used. https://github.com/googleapis/python-storage/issues/501