### PR TITLE
Feature/bytes or string function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Allow attempt for download_as_string or as_bytes since it depends on the google-cloud-storage version.
 
 1.3.2
 -----

--- a/gsecrets/client.py
+++ b/gsecrets/client.py
@@ -63,7 +63,10 @@ class Client(object):
         # TODO: error handling if this file is missing or badly configured
         path = "keyring.json"
         blob = self.bucket.blob(path)
-        keyring_configuration = blob.download_as_bytes()
+        try:
+            keyring_configuration = blob.download_as_bytes()
+        except:
+            keyring_configuration = blob.download_as_string()
         keyring_configuration = json.loads(keyring_configuration)
         self.location = keyring_configuration["location"]
         self.keyring = keyring_configuration["keyring"]
@@ -184,7 +187,10 @@ class Client(object):
         blob = self.bucket.blob(path)
 
         try:
-            ciphertext = blob.download_as_bytes()
+            try:
+                ciphertext = blob.download_as_bytes()
+            except:
+                ciphertext = blob.download_as_string()
         except NotFound:
             raise SecretNotFound()
 


### PR DESCRIPTION
Adds a try-except since download_as_string is broken during deprecation but required for older google-cloud-storage versions.